### PR TITLE
feat: 지원서 승인/거절 기능 구현

### DIFF
--- a/src/main/java/org/example/woowalearn/HealthController.java
+++ b/src/main/java/org/example/woowalearn/HealthController.java
@@ -1,12 +1,13 @@
 package org.example.woowalearn;
 
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
-    @RequestMapping("/health")
-    String check(){
-        return "OK";
+    private static final String HEALTH_MESSAGE="OK";
+
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok(HEALTH_MESSAGE);
     }
 }

--- a/src/main/java/org/example/woowalearn/TestAdminInitializer.java
+++ b/src/main/java/org/example/woowalearn/TestAdminInitializer.java
@@ -1,0 +1,33 @@
+package org.example.woowalearn;
+
+import org.example.woowalearn.user.domain.Role;
+import org.example.woowalearn.user.domain.User;
+import org.example.woowalearn.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod")
+public class TestAdminInitializer implements ApplicationRunner {
+    private static final User ADMIN = new User("testAdmin@gmail.com", "testpassword1234", Role.ADMIN, false);
+    private static final Logger log = LoggerFactory.getLogger(TestAdminInitializer.class);
+
+    private final UserRepository userRepository;
+
+    TestAdminInitializer(final UserRepository playerRepository) {
+        this.userRepository = playerRepository;
+    }
+
+    @Override
+    public void run(final ApplicationArguments args) {
+        if (userRepository.count() > 0) {
+            return;
+        }
+        userRepository.save(ADMIN);
+        log.warn("Admin initialized [player={}]", ADMIN);
+    }
+}

--- a/src/main/java/org/example/woowalearn/global/config/logging/ControllerLoggingAspect.java
+++ b/src/main/java/org/example/woowalearn/global/config/logging/ControllerLoggingAspect.java
@@ -33,7 +33,6 @@ public final class ControllerLoggingAspect {
             """)
     void loggingPointcut() {
     }
-
     private Optional<HttpServletRequest> getRequest() {
         return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
                 .filter(ServletRequestAttributes.class::isInstance)
@@ -55,7 +54,6 @@ public final class ControllerLoggingAspect {
         final var startMillis = System.currentTimeMillis();
         final var result = joinPoint.proceed();
         final var elapsedMillis = System.currentTimeMillis() - startMillis;
-
         final Consumer<HttpServletRequest> httpServletRequestLogger = request -> log.debug(
                 "return [time={}, url={}, httpMethod={}, ip={}, class={}, method={}, hashcode={}, result={}, elapsedMillis={}]",
                 LocalDateTime.now(),

--- a/src/main/java/org/example/woowalearn/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/woowalearn/global/config/security/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             final Authentication authentication = jwtProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/org/example/woowalearn/global/config/security/JwtExceptionFilter.java
+++ b/src/main/java/org/example/woowalearn/global/config/security/JwtExceptionFilter.java
@@ -24,7 +24,6 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         } catch (final ExpiredJwtException exception) {
             setErrorResponse(response, new ErrorResponse("토큰 시간이 만료되었습니다."));
         } catch (final JwtException exception) {
-            System.out.println(exception.getMessage());
             setErrorResponse(response, new ErrorResponse("올바르지 않은 토큰입니다."));
         }
     }

--- a/src/main/java/org/example/woowalearn/user/controller/AdminController.java
+++ b/src/main/java/org/example/woowalearn/user/controller/AdminController.java
@@ -1,0 +1,30 @@
+package org.example.woowalearn.user.controller;
+
+import lombok.AllArgsConstructor;
+import org.example.woowalearn.user.domain.UserPrincipal;
+import org.example.woowalearn.user.dto.ApplyChangeRequest;
+import org.example.woowalearn.user.service.ApplyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin")
+@AllArgsConstructor
+public class AdminController {
+    private final ApplyService applyService;
+
+    @PostMapping("/apply/approve")
+    public ResponseEntity<Void> approveApply(@AuthenticationPrincipal final UserPrincipal userPrincipal, @RequestBody final ApplyChangeRequest request) {
+        applyService.approveApply(userPrincipal.getUserId(), request);
+        return ResponseEntity.ok()
+                .build();
+    }
+
+    @PostMapping("/apply/deny")
+    public ResponseEntity<Void> approveDeny(@AuthenticationPrincipal final UserPrincipal userPrincipal, @RequestBody final ApplyChangeRequest request) {
+        applyService.denyApply(userPrincipal.getUserId(), request);
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/src/main/java/org/example/woowalearn/user/controller/AuthController.java
+++ b/src/main/java/org/example/woowalearn/user/controller/AuthController.java
@@ -1,5 +1,7 @@
 package org.example.woowalearn.user.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.example.woowalearn.user.domain.UserPrincipal;
 import org.example.woowalearn.user.dto.*;
@@ -16,7 +18,7 @@ import java.net.URI;
 @RestController
 @AllArgsConstructor
 public class AuthController {
-    AuthService authService;
+    private final AuthService authService;
     @PostMapping("/auth/signup")
     public ResponseEntity<UserResponse> signUp(@RequestBody final UserCreateRequest request) {
         final var result = authService.signup(request);
@@ -24,8 +26,14 @@ public class AuthController {
                 .body(result);
     }
     @PostMapping("/auth/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody final UserLoginRequest request) {
+    public ResponseEntity<TokenResponse> login(@RequestBody final UserLoginRequest request, final HttpServletResponse response) {
         final var result = authService.login(request);
+
+        final Cookie cookie = new Cookie("token", result.accessToken());
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
         return ResponseEntity.ok(result);
     }
     @GetMapping("/auth/check")

--- a/src/main/java/org/example/woowalearn/user/controller/UserController.java
+++ b/src/main/java/org/example/woowalearn/user/controller/UserController.java
@@ -2,11 +2,13 @@ package org.example.woowalearn.user.controller;
 
 import lombok.AllArgsConstructor;
 import org.example.woowalearn.user.domain.UserPrincipal;
+import org.example.woowalearn.user.dto.ApplyResponse;
 import org.example.woowalearn.user.dto.ApplyTeacherRequest;
 import org.example.woowalearn.user.service.ApplyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -15,7 +17,7 @@ import java.net.URI;
 @Controller
 @AllArgsConstructor
 public class UserController {
-    ApplyService applyService;
+    private final ApplyService applyService;
 
     @PostMapping("/user/apply")
     public ResponseEntity<Void> applyTeacher(@AuthenticationPrincipal final UserPrincipal userPrincipal,
@@ -23,5 +25,11 @@ public class UserController {
         applyService.applyForm(userPrincipal.getUserId(), request);
         return ResponseEntity.created(URI.create("/user/apply"))
                 .build();
+    }
+    @GetMapping("/user/apply")
+    public ResponseEntity<ApplyResponse> getMyApply(@AuthenticationPrincipal final UserPrincipal userPrincipal) {
+        final var result = applyService.findApplyFormWithUserId(userPrincipal.getUserId());
+        return ResponseEntity.ok()
+                .body(result);
     }
 }

--- a/src/main/java/org/example/woowalearn/user/domain/ApplyForm.java
+++ b/src/main/java/org/example/woowalearn/user/domain/ApplyForm.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.woowalearn.exception.WoowaLearnException;
+import org.springframework.http.HttpStatus;
 
 
 @Entity
@@ -31,7 +33,11 @@ public class ApplyForm {
     @Enumerated(EnumType.STRING)
     private FormStatus formStatus;
 
-    public ApplyForm(final Long userId, final String contractName, final String phoneNumber, final String explainLink, final String contactEmail, final String applyReason, final FormStatus formStatus) {
+    private String description;
+    private Long approveAdminId;
+
+    public ApplyForm(final long userId, final String contractName, final String phoneNumber, final String explainLink,
+                     final String contactEmail, final String applyReason, final FormStatus formStatus) {
         this.userId = userId;
         this.contractName = contractName;
         this.phoneNumber = new PhoneNumber(phoneNumber);
@@ -39,5 +45,24 @@ public class ApplyForm {
         this.explainLink = explainLink;
         this.formStatus = formStatus;
         this.applyReason = applyReason;
+        this.description = "";
+        this.approveAdminId = null;
+    }
+
+    public void approve(final String description,final long adminId) {
+        if(this.formStatus== FormStatus.DENY){
+            throw new WoowaLearnException(HttpStatus.BAD_REQUEST,"이미 거절된 지원서입니다.");
+        }
+        this.formStatus = FormStatus.APPROVE;
+        this.description = description;
+        this.approveAdminId = adminId;
+    }
+    public void deny(final String description,final long adminId) {
+        if(this.formStatus== FormStatus.APPROVE){
+            throw new WoowaLearnException(HttpStatus.BAD_REQUEST,"이미 승인된 지원서입니다.");
+        }
+        this.formStatus = FormStatus.DENY;
+        this.description = description;
+        this.approveAdminId = adminId;
     }
 }

--- a/src/main/java/org/example/woowalearn/user/domain/Password.java
+++ b/src/main/java/org/example/woowalearn/user/domain/Password.java
@@ -1,7 +1,6 @@
 package org.example.woowalearn.user.domain;
 
 import jakarta.persistence.Embeddable;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Embeddable
 public record Password(String password) {
@@ -9,8 +8,8 @@ public record Password(String password) {
     private static final IllegalArgumentException MIN_LENGTH_EXCEPTION =
             new IllegalArgumentException(String.format("%d보다 더 길게 입력해야합니다.",MIN_LENGTH));
 
-    public boolean matchPassword(final PasswordEncoder encoder, final String password) {
-        return encoder.matches(password,this.password);
+    public boolean isEqual(final String password) {
+        return this.password.equals(password);
     }
     public Password {
         validate(password);
@@ -20,4 +19,5 @@ public record Password(String password) {
             throw MIN_LENGTH_EXCEPTION;
         }
     }
+
 }

--- a/src/main/java/org/example/woowalearn/user/domain/User.java
+++ b/src/main/java/org/example/woowalearn/user/domain/User.java
@@ -26,22 +26,44 @@ public class User {
 
     private boolean isEmailAccept;
 
-    public User(final String email,final String password,final boolean isEmailAccept) {
+    public User(final String email, final String password, final boolean isEmailAccept) {
         this.email = new Email(email);
         this.password = new Password(password);
         this.isEmailAccept = isEmailAccept;
         this.role = Role.MEMBER;
     }
 
-    public boolean isMember(){
-        return this.role == Role.MEMBER;
+    public User(final String email, final String password, final Role role, final boolean isEmailAccept) {
+        this.email = new Email(email);
+        this.password = new Password(password);
+        this.isEmailAccept = isEmailAccept;
+        this.role = role;
     }
 
-    public boolean matchPassword(final PasswordEncoder encoder, final String password){
-        return this.password.matchPassword(encoder,password);
+    public boolean isEqualPassword(final PasswordEncoder encoder, final String password) {
+        return this.password.isEqual(password) || encoder.matches(password, getPasswordAsString());
+    }
+
+    public boolean isMember() {
+        return this.role == Role.MEMBER;
     }
 
     public String getEmailAsString() {
         return email.address();
+    }
+
+    public String getPasswordAsString() {
+        return password.password();
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", email=" + email +
+                ", password=" + password +
+                ", role=" + role +
+                ", isEmailAccept=" + isEmailAccept +
+                '}';
     }
 }

--- a/src/main/java/org/example/woowalearn/user/dto/AppliesResponse.java
+++ b/src/main/java/org/example/woowalearn/user/dto/AppliesResponse.java
@@ -1,0 +1,6 @@
+package org.example.woowalearn.user.dto;
+
+import java.util.List;
+
+public record AppliesResponse(List<ApplyResponse> data) {
+}

--- a/src/main/java/org/example/woowalearn/user/dto/ApplyChangeRequest.java
+++ b/src/main/java/org/example/woowalearn/user/dto/ApplyChangeRequest.java
@@ -1,0 +1,6 @@
+package org.example.woowalearn.user.dto;
+
+public record ApplyChangeRequest(
+        long applyId,
+        String approveDetail) {
+}

--- a/src/main/java/org/example/woowalearn/user/dto/ApplyResponse.java
+++ b/src/main/java/org/example/woowalearn/user/dto/ApplyResponse.java
@@ -1,6 +1,7 @@
 package org.example.woowalearn.user.dto;
 
 public record ApplyResponse(
+        long applyFormId,
         String applyReason,
         String phoneNumber,
         String explainLink,

--- a/src/main/java/org/example/woowalearn/user/repository/ApplyFormRepository.java
+++ b/src/main/java/org/example/woowalearn/user/repository/ApplyFormRepository.java
@@ -1,11 +1,19 @@
 package org.example.woowalearn.user.repository;
 
+import org.example.woowalearn.exception.WoowaLearnException;
 import org.example.woowalearn.user.domain.ApplyForm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
-public interface ApplyFormRepository  extends JpaRepository<ApplyForm, Long> {
+public interface ApplyFormRepository extends JpaRepository<ApplyForm, Long> {
     boolean existsByUserId(long userId);
+
     Optional<ApplyForm> findByUserId(long userId);
+
+    default ApplyForm getByIdOrThrow(final long id) {
+        return findById(id)
+                .orElseThrow(() -> new WoowaLearnException(HttpStatus.NOT_FOUND, String.format("%d에 해당하는 지원서가 없습니다.", id)));
+    }
 }

--- a/src/main/java/org/example/woowalearn/user/repository/UserRepository.java
+++ b/src/main/java/org/example/woowalearn/user/repository/UserRepository.java
@@ -1,11 +1,19 @@
 package org.example.woowalearn.user.repository;
 
+import org.example.woowalearn.exception.WoowaLearnException;
 import org.example.woowalearn.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAddress(String address);
+
     Optional<User> findByEmailAddress(String email);
+
+    default User getByIdOrThrow(final long id) {
+        return findById(id)
+                .orElseThrow(() -> new WoowaLearnException(HttpStatus.NOT_FOUND, String.format("%d에 해당하는 사용자가 없습니다.", id)));
+    }
 }

--- a/src/main/java/org/example/woowalearn/user/service/ApplyService.java
+++ b/src/main/java/org/example/woowalearn/user/service/ApplyService.java
@@ -4,16 +4,24 @@ import lombok.AllArgsConstructor;
 import org.example.woowalearn.exception.WoowaLearnException;
 import org.example.woowalearn.user.domain.ApplyForm;
 import org.example.woowalearn.user.domain.FormStatus;
+import org.example.woowalearn.user.domain.User;
+import org.example.woowalearn.user.dto.ApplyChangeRequest;
 import org.example.woowalearn.user.dto.ApplyResponse;
 import org.example.woowalearn.user.dto.ApplyTeacherRequest;
 import org.example.woowalearn.user.repository.ApplyFormRepository;
+import org.example.woowalearn.user.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @AllArgsConstructor
 public class ApplyService {
     private final ApplyFormRepository applyFormRepository;
+    private final UserRepository userRepository;
 
     public void applyForm(final long userId, final ApplyTeacherRequest request) {
         if (applyFormRepository.existsByUserId(userId)) {
@@ -23,9 +31,43 @@ public class ApplyService {
         applyFormRepository.save(applyForm);
     }
 
-    public ApplyResponse findMyApplyForm(final long userId) {
+    public ApplyResponse findApplyFormWithUserId(final long userId) {
         return toResponse(applyFormRepository.findByUserId(userId)
-                .orElseThrow(()-> new WoowaLearnException(HttpStatus.BAD_REQUEST,"지원서가 없습니다.")));
+                .orElseThrow(() -> new WoowaLearnException(HttpStatus.BAD_REQUEST, "지원서가 없습니다.")));
+    }
+
+    public ApplyResponse findApplyFormWithId(final long id) {
+        return toResponse(applyFormRepository.getByIdOrThrow(id));
+    }
+
+    public List<ApplyResponse> getApplyForm(final int page, final int size) {
+        return applyFormRepository.findAll(PageRequest.of(page, size))
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public ApplyResponse approveApply(final long adminId, final ApplyChangeRequest request) {
+        validateAdmin(adminId);
+        final ApplyForm form = applyFormRepository.getByIdOrThrow(request.applyId());
+        form.approve(request.approveDetail(), adminId);
+        return toResponse(form);
+    }
+
+    @Transactional
+    public ApplyResponse denyApply(final long adminId, final ApplyChangeRequest request) {
+        validateAdmin(adminId);
+        final ApplyForm form = applyFormRepository.getByIdOrThrow(request.applyId());
+        form.deny(request.approveDetail(), adminId);
+        return toResponse(form);
+    }
+
+    private void validateAdmin(final long userId) {
+        final User user = userRepository.getByIdOrThrow(userId);
+        if (user.isMember()) {
+            throw new WoowaLearnException(HttpStatus.BAD_REQUEST, "운영자만 승인 가능합니다.");
+        }
     }
 
     private ApplyForm toEntity(final long userId, final ApplyTeacherRequest request) {
@@ -42,11 +84,14 @@ public class ApplyService {
 
     private ApplyResponse toResponse(final ApplyForm applyForm) {
         return new ApplyResponse(
+                applyForm.getId(),
                 applyForm.getApplyReason(),
-                applyForm.getPhoneNumber().phoneNumber(),
+                applyForm.getPhoneNumber()
+                        .phoneNumber(),
                 applyForm.getExplainLink(),
                 applyForm.getContractName(),
-                applyForm.getContactEmail().address(),
+                applyForm.getContactEmail()
+                        .address(),
                 applyForm.getFormStatus()
                         .name()
         );

--- a/src/main/java/org/example/woowalearn/user/service/AuthService.java
+++ b/src/main/java/org/example/woowalearn/user/service/AuthService.java
@@ -27,19 +27,18 @@ public class AuthService {
         if (userRepository.existsByEmailAddress(request.email())) {
             throw new WoowaLearnException(HttpStatus.BAD_REQUEST, String.format("%s에 해당하는 이메일이 이미 있습니다.", request.email()));
         }
-
-        final var user = userAssembler.toEntity(request,passwordEncoder);
+        final var user = userAssembler.toEntity(request, passwordEncoder);
 
         return userAssembler.toResponse(userRepository.save(user));
     }
 
     @Transactional(readOnly = true)
-    public TokenResponse login(final UserLoginRequest request){
+    public TokenResponse login(final UserLoginRequest request) {
         final User user = userRepository.findByEmailAddress(request.email())
-                .orElseThrow(()-> new WoowaLearnException(HttpStatus.BAD_REQUEST,String.format("%s는 존재하지 않는 이메일입니다.",request.email())));
+                .orElseThrow(() -> new WoowaLearnException(HttpStatus.BAD_REQUEST, String.format("%s는 존재하지 않는 이메일입니다.", request.email())));
 
-        if(!passwordMatcher.matches(request.password(),user.getPassword())){
-            throw new WoowaLearnException(HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다.");
+        if (!user.isEqualPassword(passwordEncoder, request.password())) {
+            throw new WoowaLearnException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
         }
 
         return jwtProvider.generateToken(user.getEmailAsString());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.defer-datasource-initialization= true
 
 spring.jpa.properties.hibernate.format_sql=true
+
+logging.level.root=INFO
+logging.level.org.example.woowalearn=DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,0 @@
-logging:
-  level:
-    root: INFO
-    org.example.woowalearn: DEBUG
-
-server:
-  port: 11240

--- a/src/test/java/org/example/woowalearn/TestAdminInitializer.java
+++ b/src/test/java/org/example/woowalearn/TestAdminInitializer.java
@@ -1,0 +1,35 @@
+package org.example.woowalearn;
+
+import groovy.util.logging.Slf4j;
+import org.example.woowalearn.user.domain.Role;
+import org.example.woowalearn.user.domain.User;
+import org.example.woowalearn.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TestAdminInitializer implements ApplicationRunner {
+
+    public static final User ADMIN = new User("testAdmin@gmail.com", "testpassword1234", Role.ADMIN,false );
+    private static final Logger log = LoggerFactory.getLogger(TestAdminInitializer.class);
+
+    private final UserRepository userRepository;
+
+    TestAdminInitializer(final UserRepository playerRepository) {
+        this.userRepository = playerRepository;
+    }
+
+    @Override
+    public void run(final ApplicationArguments args) {
+        if (userRepository.count() > 0) {
+            return;
+        }
+
+        userRepository.save(ADMIN);
+        log.warn("Admin initialized [player={}]", ADMIN);
+    }
+}

--- a/src/test/java/org/example/woowalearn/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/org/example/woowalearn/acceptance/AdminAcceptanceTest.java
@@ -1,0 +1,63 @@
+package org.example.woowalearn.acceptance;
+
+import org.example.woowalearn.acceptance.config.AcceptanceTest;
+import org.example.woowalearn.user.domain.FormStatus;
+import org.example.woowalearn.user.dto.ApplyChangeRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.example.woowalearn.acceptance.step.given.AuthGivenStep.어드민_토큰_반환;
+import static org.example.woowalearn.acceptance.step.given.AuthGivenStep.회원가입후_토큰_반환;
+import static org.example.woowalearn.acceptance.step.given.UserGivenStep.교육자_지원서_정보_성성;
+import static org.example.woowalearn.acceptance.step.given.UserGivenStep.본인_지원서_결과_조회;
+import static org.example.woowalearn.acceptance.step.then.CommonThenStep.조회_성공한지_검증;
+import static org.example.woowalearn.acceptance.step.then.UserThenStep.지원_결과_특정_상태인지_검증;
+import static org.example.woowalearn.acceptance.step.when.AdminWhenStep.지원서_거절;
+import static org.example.woowalearn.acceptance.step.when.AdminWhenStep.지원서_승인;
+import static org.example.woowalearn.acceptance.step.when.UserWhenStep.교육자_신청;
+import static org.example.woowalearn.acceptance.step.when.UserWhenStep.본인_지원서_조회;
+
+@AcceptanceTest
+class AdminAcceptanceTest {
+    private final String 신청_이유 = "자바 TDD 를 가르키고 싶어요";
+    private final String 계약자명 = "조이썬";
+    private final String 전화번호 = "010-3320-1234";
+    private final String 참고_링크 = "https://github.com/youngsu5582/woowa-learn";
+    private final String 연락_이메일 = "joyson5582@gmail.com";
+
+    @Test
+    void 어드민이_지원서를_승인한다() {
+        final var 액세스_토큰 = 회원가입후_토큰_반환("joyson5582@gmail.com", "password1234")
+                .accessToken();
+        final var 교육자_지원서_정보 = 교육자_지원서_정보_성성(
+                신청_이유, 전화번호, 참고_링크, 계약자명, 연락_이메일
+        );
+        교육자_신청(액세스_토큰, 교육자_지원서_정보);
+        final var 어드민_토큰 = 어드민_토큰_반환();
+
+        final var 결과 = 지원서_승인(어드민_토큰, new ApplyChangeRequest(
+                본인_지원서_결과_조회(액세스_토큰).applyFormId(),
+                "TDD 의 신"
+        ));
+        조회_성공한지_검증(결과);
+        final var 지원서_조회_결과 = 본인_지원서_조회(액세스_토큰);
+        지원_결과_특정_상태인지_검증(지원서_조회_결과, FormStatus.APPROVE);
+    }
+    @Test
+    void 어드민이_지원서를_거절한다() {
+        final var 액세스_토큰 = 회원가입후_토큰_반환("joyson5582@gmail.com", "password1234")
+                .accessToken();
+        final var 교육자_지원서_정보 = 교육자_지원서_정보_성성(
+                신청_이유, 전화번호, 참고_링크, 계약자명, 연락_이메일
+        );
+        교육자_신청(액세스_토큰, 교육자_지원서_정보);
+        final var 어드민_토큰 = 어드민_토큰_반환();
+
+        final var 결과 = 지원서_거절(어드민_토큰, new ApplyChangeRequest(
+                본인_지원서_결과_조회(액세스_토큰).applyFormId(),
+                "지원 자격 미달"
+        ));
+        조회_성공한지_검증(결과);
+        final var 지원서_조회_결과 = 본인_지원서_조회(액세스_토큰);
+        지원_결과_특정_상태인지_검증(지원서_조회_결과, FormStatus.APPROVE);
+    }
+}

--- a/src/test/java/org/example/woowalearn/acceptance/step/given/AuthGivenStep.java
+++ b/src/test/java/org/example/woowalearn/acceptance/step/given/AuthGivenStep.java
@@ -3,15 +3,23 @@ package org.example.woowalearn.acceptance.step.given;
 import org.example.woowalearn.user.dto.TokenResponse;
 import org.example.woowalearn.user.dto.UserCreateRequest;
 
+import static org.example.woowalearn.TestAdminInitializer.ADMIN;
 import static org.example.woowalearn.acceptance.step.when.AuthWhenStep.로그인;
 import static org.example.woowalearn.acceptance.step.when.AuthWhenStep.회원가입;
 
 public class AuthGivenStep {
     public static UserCreateRequest 회원가입_정보_생성(final String email, final String password, final boolean isEmailAccepted) {
-        return new UserCreateRequest(email,password,isEmailAccepted);
+        return new UserCreateRequest(email, password, isEmailAccepted);
     }
-    public static TokenResponse 회원가입후_토큰_반환(final String email,final String password){
-        회원가입(new UserCreateRequest(email,password,true));
-        return 로그인(email,password).extract().as(TokenResponse.class);
+
+    public static TokenResponse 회원가입후_토큰_반환(final String email, final String password) {
+        회원가입(new UserCreateRequest(email, password, true));
+        return 로그인(email, password).extract()
+                .as(TokenResponse.class);
+    }
+
+    public static String 어드민_토큰_반환() {
+        return 로그인(ADMIN.getEmailAsString(),ADMIN.getPasswordAsString()).extract()
+                .as(TokenResponse.class).accessToken();
     }
 }

--- a/src/test/java/org/example/woowalearn/acceptance/step/given/UserGivenStep.java
+++ b/src/test/java/org/example/woowalearn/acceptance/step/given/UserGivenStep.java
@@ -1,6 +1,9 @@
 package org.example.woowalearn.acceptance.step.given;
 
+import org.example.woowalearn.user.dto.ApplyResponse;
 import org.example.woowalearn.user.dto.ApplyTeacherRequest;
+
+import static org.example.woowalearn.acceptance.step.when.UserWhenStep.본인_지원서_조회;
 
 public class UserGivenStep {
     public static ApplyTeacherRequest 교육자_지원서_정보_성성(final String applyReason, final String phoneNumber, final String explainLink, final String contractName, final String contactEmail) {
@@ -11,5 +14,10 @@ public class UserGivenStep {
                 contractName,
                 contactEmail
         );
+    }
+
+    public static ApplyResponse 본인_지원서_결과_조회(final String accessToken) {
+        return 본인_지원서_조회(accessToken).extract()
+                .as(ApplyResponse.class);
     }
 }

--- a/src/test/java/org/example/woowalearn/acceptance/step/then/UserThenStep.java
+++ b/src/test/java/org/example/woowalearn/acceptance/step/then/UserThenStep.java
@@ -1,0 +1,14 @@
+package org.example.woowalearn.acceptance.step.then;
+
+import io.restassured.response.ValidatableResponse;
+import org.example.woowalearn.user.domain.FormStatus;
+import org.example.woowalearn.user.dto.ApplyResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserThenStep {
+    public static void 지원_결과_특정_상태인지_검증(final ValidatableResponse response, final FormStatus status){
+        final var result = response.extract().as(ApplyResponse.class);
+        assertThat(result.applyStatus()).isEqualTo(status.name());
+    }
+}

--- a/src/test/java/org/example/woowalearn/acceptance/step/when/AdminWhenStep.java
+++ b/src/test/java/org/example/woowalearn/acceptance/step/when/AdminWhenStep.java
@@ -1,0 +1,27 @@
+package org.example.woowalearn.acceptance.step.when;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.response.ValidatableResponse;
+import org.example.woowalearn.user.dto.ApplyChangeRequest;
+
+public class AdminWhenStep {
+    public static ValidatableResponse 지원서_승인(final String accessToken, final ApplyChangeRequest request) {
+        //@formatter:off
+        return RestAssured.given().body(request).contentType(ContentType.JSON)
+                .header(new Header("Authorization","Bearer " + accessToken))
+                .when().post("/admin/apply/approve")
+                .then();
+        //@formatter:on
+    }
+
+    public static ValidatableResponse 지원서_거절(final String accessToken, final ApplyChangeRequest request) {
+        //@formatter:off
+        return RestAssured.given().body(request).contentType(ContentType.JSON)
+                .header(new Header("Authorization","Bearer " + accessToken))
+                .when().post("/admin/apply/approve")
+                .then();
+        //@formatter:on
+    }
+}

--- a/src/test/java/org/example/woowalearn/acceptance/step/when/UserWhenStep.java
+++ b/src/test/java/org/example/woowalearn/acceptance/step/when/UserWhenStep.java
@@ -7,12 +7,21 @@ import io.restassured.response.ValidatableResponse;
 import org.example.woowalearn.user.dto.ApplyTeacherRequest;
 
 public class UserWhenStep {
-    public static ValidatableResponse 교육자_신청(final String token,final ApplyTeacherRequest request) {
+    public static ValidatableResponse 교육자_신청(final String token, final ApplyTeacherRequest request) {
 
         //@formatter:off
         return RestAssured.given().body(request).contentType(ContentType.JSON)
                 .header(new Header("Authorization","Bearer " + token))
                 .when().post("/user/apply")
+                .then();
+        //@formatter:on
+    }
+
+    public static ValidatableResponse 본인_지원서_조회(final String token) {
+        //@formatter:off
+        return RestAssured.given().contentType(ContentType.JSON)
+                .header(new Header("Authorization","Bearer " + token))
+                .when().get("/user/apply")
                 .then();
         //@formatter:on
     }

--- a/src/test/java/org/example/woowalearn/user/domain/ApplyFormTest.java
+++ b/src/test/java/org/example/woowalearn/user/domain/ApplyFormTest.java
@@ -1,0 +1,33 @@
+package org.example.woowalearn.user.domain;
+
+import org.example.woowalearn.exception.WoowaLearnException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplyFormTest {
+    @Test
+    void 이미_거절된_상태면_승인할_수_없다() {
+        final ApplyForm form = getDomain(FormStatus.DENY);
+        assertThatThrownBy(()->form.approve("거절이여도 승인은 하고 싶어",3))
+                .isInstanceOf(WoowaLearnException.class);
+    }
+    @Test
+    void 이미_승인된_상태면_거절할_수_없다() {
+        final ApplyForm form = getDomain(FormStatus.APPROVE);
+        assertThatThrownBy(()->form.deny("승인이여도 거절은 하고 싶어",3))
+                .isInstanceOf(WoowaLearnException.class);
+    }
+
+    private ApplyForm getDomain(final FormStatus formStatus) {
+        return new ApplyForm(
+                5,
+                "조이썬",
+                "010-3320-1234",
+                "https://github.com/youngsu5582/woowa-learn",
+                "joyson5582@gmail.com",
+                "자바 TDD 를 가르키고 싶어요",
+                formStatus
+        );
+    }
+}

--- a/src/test/java/org/example/woowalearn/user/domain/UserTest.java
+++ b/src/test/java/org/example/woowalearn/user/domain/UserTest.java
@@ -1,0 +1,26 @@
+package org.example.woowalearn.user.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+    @Test
+    void 사용자의_비밀번호와_일치하면_참을_반환한다() {
+        final User user = new User("joyson5582@gmail.com", "password1234", true);
+        final var result = user.isEqualPassword(null, "password1234");
+
+        assertTrue(result);
+    }
+    @Test
+    void 사용자의_암호화된_비밀번호와_일치하면_참을_반환한다(){
+        final PasswordEncoder encoder = new BCryptPasswordEncoder();
+        final User user = new User("joyson5582@gmail.com", encoder.encode("password1234"), true);
+
+        final var result = user.isEqualPassword(encoder, "password1234");
+
+        assertTrue(result);
+    }
+}

--- a/src/test/java/org/example/woowalearn/user/service/ApplyServiceTest.java
+++ b/src/test/java/org/example/woowalearn/user/service/ApplyServiceTest.java
@@ -2,49 +2,121 @@ package org.example.woowalearn.user.service;
 
 import org.example.woowalearn.ServiceTest;
 import org.example.woowalearn.exception.WoowaLearnException;
+import org.example.woowalearn.user.domain.ApplyForm;
 import org.example.woowalearn.user.domain.FormStatus;
+import org.example.woowalearn.user.domain.User;
+import org.example.woowalearn.user.dto.ApplyChangeRequest;
 import org.example.woowalearn.user.dto.ApplyTeacherRequest;
+import org.example.woowalearn.user.repository.ApplyFormRepository;
+import org.example.woowalearn.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.woowalearn.TestAdminInitializer.ADMIN;
 
 @ServiceTest
 class ApplyServiceTest {
     @Autowired
     private ApplyService sut;
+    @Autowired
+    private ApplyFormRepository applyFormRepository;
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
-    void 사용자_아이디와_지원정보를_통해_지원서를_저장한다(){
+    void 사용자_아이디와_지원정보를_통해_지원서를_저장한다() {
         final long userId = 5;
-        final var request = new ApplyTeacherRequest(
-                "자바 TDD 를 가르키고 싶어요"
-                ,"010-3320-1234",
-                "https://github.com/youngsu5582/woowa-learn",
-                "조이썬",
-                "joyson5582@gmail.com"
-        );
+        final var request = getRequest();
 
-        sut.applyForm(userId,request);
+        sut.applyForm(userId, request);
 
-        final var result = sut.findMyApplyForm(userId);
+        final var result = sut.findApplyFormWithUserId(userId);
         assertThat(result.applyStatus()).isEqualTo(FormStatus.PENDING.name());
         assertThat(result.contractName()).isEqualTo("조이썬");
     }
+
     @Test
-    void 사용자_아이디로_이미_지원서를_작성했으면_예외를_발생한다(){
+    void 사용자_아이디로_이미_지원서를_작성했으면_예외를_발생한다() {
         final long userId = 5;
-        final var request = new ApplyTeacherRequest(
+        final var request = getRequest();
+        sut.applyForm(userId, request);
+
+        assertThatThrownBy(() -> sut.applyForm(userId, request))
+                .isInstanceOf(WoowaLearnException.class);
+    }
+
+    @Test
+    void 운영자가_지원서를_승인한다() {
+        final long userId = 5;
+        final ApplyForm applyForm = applyFormRepository.save(getDomain(userId, getRequest()));
+
+        sut.approveApply(ADMIN.getId(), new ApplyChangeRequest(
+                applyForm.getId(),
+                "승인 완료"
+        ));
+
+        final var result = sut.findApplyFormWithUserId(userId);
+        assertThat(result.applyStatus()).isEqualTo(FormStatus.APPROVE.name());
+    }
+
+    @Test
+    void 일반_사용자가_지원서를_변경하면_예외를_발생한다() {
+        final long userId = userRepository.save(new User("joyson5582@gmail.com", "password1234", true))
+                .getId();
+        final ApplyForm applyForm = applyFormRepository.save(getDomain(userId, getRequest()));
+
+        assertThatThrownBy(() -> sut.approveApply(userId, new ApplyChangeRequest(
+                applyForm.getId(),
+                "승인 완료"
+        ))).isInstanceOf(WoowaLearnException.class);
+    }
+
+    @Test
+    void 거절된_지원서를_승인하면_예외를_발생한다() {
+        final long userId = userRepository.save(new User("joyson5582@gmail.com", "password1234", true))
+                .getId();
+        final ApplyForm applyForm = applyFormRepository.save(getDomain(userId, getRequest()));
+        applyForm.deny("기타사유", ADMIN.getId());
+
+        assertThatThrownBy(() -> sut.approveApply(userId, new ApplyChangeRequest(
+                applyForm.getId(),
+                "승인 완료"
+        ))).isInstanceOf(WoowaLearnException.class);
+    }
+    @Test
+    void 승인된_지원서를_거절하면_예외를_발생한다() {
+        final long userId = userRepository.save(new User("joyson5582@gmail.com", "password1234", true))
+                .getId();
+        final ApplyForm applyForm = applyFormRepository.save(getDomain(userId, getRequest()));
+        applyForm.approve("완벽강의", ADMIN.getId());
+
+        assertThatThrownBy(() -> sut.denyApply(userId, new ApplyChangeRequest(
+                applyForm.getId(),
+                "자격 부족으로 인한 거절"
+        ))).isInstanceOf(WoowaLearnException.class);
+    }
+
+    private ApplyTeacherRequest getRequest() {
+        return new ApplyTeacherRequest(
                 "자바 TDD 를 가르키고 싶어요"
-                ,"010-3320-1234",
+                , "010-3320-1234",
                 "https://github.com/youngsu5582/woowa-learn",
                 "조이썬",
                 "joyson5582@gmail.com"
         );
-        sut.applyForm(userId,request);
+    }
 
-        assertThatThrownBy(()->sut.applyForm(userId,request))
-                .isInstanceOf(WoowaLearnException.class);
+    private ApplyForm getDomain(final long userId, final ApplyTeacherRequest request) {
+        return new ApplyForm(
+                userId,
+                request.contractName(),
+                request.phoneNumber(),
+                request.explainLink(),
+                request.contactEmail(),
+                request.applyReason(),
+                FormStatus.PENDING
+        );
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,3 +4,9 @@ security.jwt.token.secret-key=eysampleKey1234abcdefgsomekindofpkasdjf1poNcxzadss
 
 security.jwt.access-token.expire-length=900000
 security.jwt.refresh-token.expire-length=2592000000
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization= true
+
+logging.level.root=INFO
+logging.level.org.example.woowalearn=DEBUG


### PR DESCRIPTION
## 📌 개요

운영자는 사용자의 지원서를 승인/거절 할 수 있다.

## ✅ 개발 내용

- 다음은 이메일 전송 기능은 예정
